### PR TITLE
Tiny typo correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In Node.js/io.js:
 // load lodash
 var _ = require('lodash');
 // load lodash-migrate after
-require('lodash-migrate);
+require('lodash-migrate');
 
 // later when using API not supported by the latest lodash release
 _.first([1, 2, 3], 2);


### PR DESCRIPTION
Add a missing quote mark to the example.