### PR TITLE
Custom logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,20 +16,6 @@ wrapLodash(old, _);
 
 module.exports = _.partial(_.assign, config);
 
-var migrateTemplate = _.template([
-  'lodash-migrate: _.<%= name %>(<%= args %>)',
-  '  v<%= oldData.version %> => <%= oldData.result %>',
-  '  v<%= newData.version %> => <%= newData.result %>',
-  ''
-].join('\n'));
-
-var renameTemplate = _.template([
-  'lodash-migrate: Method renamed',
-  '  v<%= oldData.version %> => _.<%= oldData.name %>',
-  '  v<%= newData.version %> => _.<%= newData.name %>',
-  ''
-].join('\n'));
-
 /*----------------------------------------------------------------------------*/
 
 /**
@@ -122,7 +108,7 @@ function wrapMethod(oldDash, newDash, name) {
     };
 
     if (!ignoreRename && mapping.rename[name]) {
-      config.log(renameTemplate(data));
+      config.log(config.renameTemplate(data));
     }
     if (ignoreResult) {
       return oldFunc.apply(that, args);
@@ -141,7 +127,7 @@ function wrapMethod(oldDash, newDash, name) {
           ? !util.isEqual(oldResult, newResult)
           : util.isComparable(newResult)
         ) {
-      config.log(migrateTemplate(_.merge(data, {
+      config.log(config.migrateTemplate(_.merge(data, {
         'oldData': { 'result': util.truncate(util.inspect(oldResult)) },
         'newData': { 'result': util.truncate(util.inspect(newResult)) }
       })));

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var listing = require('./lib/listing'),
     mapping = require('./lib/mapping'),
     util = require('./lib/util');
 
-var cache = new _.memoize.Cache,
+var config = require('./lib/default-config'),
     reHasReturn = /\breturn\b/;
 
 var migrateTemplate = _.template([
@@ -25,19 +25,6 @@ var renameTemplate = _.template([
 ].join('\n'));
 
 /*----------------------------------------------------------------------------*/
-
-/**
- * Logs `value` if it hasn't been logged before.
- *
- * @private
- * @param {*} value The value to log.
- */
-function log(value) {
-  if (!cache.has(value)) {
-    cache.set(value, true);
-    console.log(value);
-  }
-}
 
 /**
  * Wraps `oldDash` methods to compare results of `oldDash` and `newDash`.
@@ -129,7 +116,7 @@ function wrapMethod(oldDash, newDash, name) {
     };
 
     if (!ignoreRename && mapping.rename[name]) {
-      log(renameTemplate(data));
+      config.log(renameTemplate(data));
     }
     if (ignoreResult) {
       return oldFunc.apply(that, args);
@@ -148,7 +135,7 @@ function wrapMethod(oldDash, newDash, name) {
           ? !util.isEqual(oldResult, newResult)
           : util.isComparable(newResult)
         ) {
-      log(migrateTemplate(_.merge(data, {
+      config.log(migrateTemplate(_.merge(data, {
         'oldData': { 'result': util.truncate(util.inspect(oldResult)) },
         'newData': { 'result': util.truncate(util.inspect(newResult)) }
       })));
@@ -159,4 +146,4 @@ function wrapMethod(oldDash, newDash, name) {
 
 /*----------------------------------------------------------------------------*/
 
-module.exports = wrapLodash(old, _);
+wrapLodash(old, _);

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function wrapMethod(oldDash, newDash, name) {
     };
 
     if (!ignoreRename && mapping.rename[name]) {
-      config.log(config.renameTemplate(data));
+      config.log(config.renameMessage(data));
     }
     if (ignoreResult) {
       return oldFunc.apply(that, args);
@@ -127,7 +127,7 @@ function wrapMethod(oldDash, newDash, name) {
           ? !util.isEqual(oldResult, newResult)
           : util.isComparable(newResult)
         ) {
-      config.log(config.migrateTemplate(_.merge(data, {
+      config.log(config.migrateMessage(_.merge(data, {
         'oldData': { 'result': util.truncate(util.inspect(oldResult)) },
         'newData': { 'result': util.truncate(util.inspect(newResult)) }
       })));

--- a/index.js
+++ b/index.js
@@ -3,20 +3,18 @@
 var _ = require('./lodash'),
     old = require('lodash');
 
-var defaultConfig = require('./lib/default-config'),
-    listing = require('./lib/listing'),
+var listing = require('./lib/listing'),
     mapping = require('./lib/mapping'),
     util = require('./lib/util');
 
-var config = {},
+var config = _.clone(require('./lib/default-config')),
     reHasReturn = /\breturn\b/;
 
 /*----------------------------------------------------------------------------*/
 
-configure(defaultConfig);
 wrapLodash(old, _);
 
-module.exports = configure;
+module.exports = _.partial(_.assign, config);
 
 var migrateTemplate = _.template([
   'lodash-migrate: _.<%= name %>(<%= args %>)',
@@ -150,13 +148,4 @@ function wrapMethod(oldDash, newDash, name) {
     }
     return oldResult;
   }));
-}
-
-/**
- * Accepts configuration options and assigns them to the config singleton.
- *
- * @param {object} options Custom configuration options
- */
-function configure (options) {
-  _.assign(config, options);
 }

--- a/index.js
+++ b/index.js
@@ -3,12 +3,20 @@
 var _ = require('./lodash'),
     old = require('lodash');
 
-var listing = require('./lib/listing'),
+var defaultConfig = require('./lib/default-config'),
+    listing = require('./lib/listing'),
     mapping = require('./lib/mapping'),
     util = require('./lib/util');
 
-var config = require('./lib/default-config'),
+var config = {},
     reHasReturn = /\breturn\b/;
+
+/*----------------------------------------------------------------------------*/
+
+configure(defaultConfig);
+wrapLodash(old, _);
+
+module.exports = configure;
 
 var migrateTemplate = _.template([
   'lodash-migrate: _.<%= name %>(<%= args %>)',
@@ -144,6 +152,11 @@ function wrapMethod(oldDash, newDash, name) {
   }));
 }
 
-/*----------------------------------------------------------------------------*/
-
-wrapLodash(old, _);
+/**
+ * Accepts configuration options and assigns them to the config singleton.
+ *
+ * @param {object} options Custom configuration options
+ */
+function configure (options) {
+  _.assign(config, options);
+}

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -8,7 +8,6 @@ module.exports = {
   /**
    * Logs `value` if it hasn't been logged before.
    *
-   * @private
    * @param {*} value The value to log.
    */
   log: function log(value) {
@@ -18,14 +17,24 @@ module.exports = {
     }
   },
 
-  migrateTemplate: _.template([
+  /**
+   * Generates the migrate warning message as a string.
+   *
+   * @param {object} data Migrate message data
+   */
+  migrateMessage: _.template([
     'lodash-migrate: _.<%= name %>(<%= args %>)',
     '  v<%= oldData.version %> => <%= oldData.result %>',
     '  v<%= newData.version %> => <%= newData.result %>',
     ''
   ].join('\n')),
 
-  renameTemplate: _.template([
+  /**
+   * Generates the rename warning message as a string.
+   *
+   * @param {object} data Rename message data
+   */
+  renameMessage: _.template([
     'lodash-migrate: Method renamed',
     '  v<%= oldData.version %> => _.<%= oldData.name %>',
     '  v<%= newData.version %> => _.<%= newData.name %>',

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -16,6 +16,20 @@ module.exports = {
       cache.set(value, true);
       console.log(value);
     }
-  }
+  },
+
+  migrateTemplate: _.template([
+    'lodash-migrate: _.<%= name %>(<%= args %>)',
+    '  v<%= oldData.version %> => <%= oldData.result %>',
+    '  v<%= newData.version %> => <%= newData.result %>',
+    ''
+  ].join('\n')),
+
+  renameTemplate: _.template([
+    'lodash-migrate: Method renamed',
+    '  v<%= oldData.version %> => _.<%= oldData.name %>',
+    '  v<%= newData.version %> => _.<%= newData.name %>',
+    ''
+  ].join('\n'))
 
 };

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var _ = require('../lodash');
+var cache = new _.memoize.Cache;
+
+module.exports = {
+
+  /**
+   * Logs `value` if it hasn't been logged before.
+   *
+   * @private
+   * @param {*} value The value to log.
+   */
+  log: function log(value) {
+    if (!cache.has(value)) {
+      cache.set(value, true);
+      console.log(value);
+    }
+  }
+
+};

--- a/test/index.js
+++ b/test/index.js
@@ -67,17 +67,10 @@ function renameText(name) {
 
 QUnit.testStart(function() {
   logs.length = 0;
+  require('../index')
 });
 
 QUnit.module('lodash-migrate');
-
-(function() {
-  QUnit.test('should return older lodash', function(assert) {
-    assert.expect(1);
-
-    assert.strictEqual(require('../index.js'), old);
-  });
-}());
 
 /*----------------------------------------------------------------------------*/
 

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,31 @@ QUnit.module('lodash-migrate');
 
 /*----------------------------------------------------------------------------*/
 
+QUnit.module('logging method');
+
+(function() {
+  QUnit.test('should be configurable', function(assert) {
+    assert.expect(1);
+
+    // Provide custom logging function
+    require('../index')({
+      log: function(message) {
+        assert.deepEqual(message, expected + '\n');
+      }
+    });
+
+    var objects = [{ 'b': 1 }, { 'b': 2 }, { 'b': 3 }],
+        expected = migrateText('max', [objects, 'b'], objects[2], objects[0]);
+
+    old.max(objects, 'b');
+
+    // Restore default configuration
+    require('../index')(require('../lib/default-config'));
+  });
+}());
+
+/*----------------------------------------------------------------------------*/
+
 QUnit.module('iteration method');
 
 (function() {


### PR DESCRIPTION
Addresses #44 

Factors out a default configuration. Presently, this configuration only provides the default logger function, but is expected to also allow configuring the `migrate` and `rename` templates.

lodash-migrate no longer returns the old lodash, but rather returns a configure function which accepts options (including custom logging function).

Open for comments. Intending to also move the `migrate` and `rename` templates over to the configuration to allow customization as well.

Feedback?