### PR TITLE
Test cleanup

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -126,38 +126,27 @@ QUnit.test('should not invoke `iteratee` in new lodash', function(assert) {
 QUnit.module('missing methods');
 
 QUnit.test('should not error on legacy `_.callback` use', function(assert) {
-  assert.expect(1);
-
   old.callback('x');
   assert.deepEqual(logs, []);
 });
 
 QUnit.test('should not error on legacy `_.contains` use', function(assert) {
-  assert.expect(1);
-
   old([1, 2, 3]).contains(2);
   assert.deepEqual(logs, [renameText('contains')]);
 });
 
 QUnit.test('should not error on legacy `_.indexBy` use', function(assert) {
-  assert.expect(1);
+  old({ 'a': 'x' }).indexBy(_.identity).value();
 
-  var object = { 'a': 'x' };
-
-  old(object).indexBy(_.identity).value();
   assert.deepEqual(logs, [renameText('indexBy')]);
 });
 
 QUnit.test('should not error on legacy `_#run` use', function(assert) {
-  assert.expect(1);
-
   old(1).run();
   assert.deepEqual(logs, [renameText('run')]);
 });
 
 QUnit.test('should not error on legacy `_.trunc` use', function(assert) {
-  assert.expect(1);
-
   var string = 'abcdef',
     expected = [renameText('trunc'), migrateText('trunc', [string, 3], '...', 'abcdef')];
 
@@ -170,8 +159,6 @@ QUnit.test('should not error on legacy `_.trunc` use', function(assert) {
 QUnit.module('mutator methods');
 
 QUnit.test('should clone arguments before invoking methods', function(assert) {
-  assert.expect(1);
-
   var array = [1, 2, 3];
 
   old.remove(array, function(value) {
@@ -182,8 +169,6 @@ QUnit.test('should clone arguments before invoking methods', function(assert) {
 });
 
 QUnit.test('should not double up on value mutations', function(assert) {
-  assert.expect(1);
-
   var array = [1, 2, 3],
     lastIndex = 0;
 
@@ -202,8 +187,6 @@ QUnit.test('should not double up on value mutations', function(assert) {
 QUnit.module('old.defer');
 
 QUnit.test('should not log', function(assert) {
-  assert.expect(1);
-
   old.defer(_.identity);
   assert.deepEqual(logs, []);
 });
@@ -213,8 +196,6 @@ QUnit.test('should not log', function(assert) {
 QUnit.module('old.delay');
 
 QUnit.test('should not log', function(assert) {
-  assert.expect(1);
-
   old.delay(_.identity, 1);
   assert.deepEqual(logs, []);
 });
@@ -224,8 +205,6 @@ QUnit.test('should not log', function(assert) {
 QUnit.module('old.mixin');
 
 QUnit.test('should not log', function(assert) {
-  assert.expect(1);
-
   old.mixin();
   assert.deepEqual(logs, []);
 });
@@ -235,8 +214,6 @@ QUnit.test('should not log', function(assert) {
 QUnit.module('old.now');
 
 QUnit.test('should not log', function(assert) {
-  assert.expect(1);
-
   old.now();
   assert.deepEqual(logs, []);
 });
@@ -246,8 +223,6 @@ QUnit.test('should not log', function(assert) {
 QUnit.module('old.runInContext');
 
 QUnit.test('should accept a `context` argument', function(assert) {
-  assert.expect(1);
-
   var count = 0;
 
   var now = function() {
@@ -266,15 +241,11 @@ QUnit.test('should accept a `context` argument', function(assert) {
 });
 
 QUnit.test('should not log', function(assert) {
-  assert.expect(1);
-
   old.runInContext();
   assert.deepEqual(logs, []);
 });
 
 QUnit.test('should wrap results', function(assert) {
-  assert.expect(1);
-
   var lodash = old.runInContext(),
     objects = [{ 'a': 1 }, { 'a': 2 }, { 'a': 3 }],
     expected = migrateText('max', [objects, 'a'], objects[2], objects[0]);
@@ -288,8 +259,6 @@ QUnit.test('should wrap results', function(assert) {
 QUnit.module('old.sample');
 
 QUnit.test('should work when chaining', function(assert) {
-  assert.expect(2);
-
   var array = [1],
     wrapped = old(array);
 
@@ -302,8 +271,6 @@ QUnit.test('should work when chaining', function(assert) {
 QUnit.module('old.times');
 
 QUnit.test('should only invoke `iteratee` in new lodash when it contains a `return` statement', function(assert) {
-  assert.expect(2);
-
   var count= 0;
   old.times(1, function() { count++; });
   assert.strictEqual(count, 1);
@@ -318,8 +285,6 @@ QUnit.test('should only invoke `iteratee` in new lodash when it contains a `retu
 QUnit.module('old.uniqueId');
 
 QUnit.test('should not log', function(assert) {
-  assert.expect(1);
-
   old.uniqueId();
   assert.deepEqual(logs, []);
 });
@@ -329,8 +294,6 @@ QUnit.test('should not log', function(assert) {
 QUnit.module('old#valueOf');
 
 QUnit.test('should not log', function(assert) {
-  assert.expect(1);
-
   old([1]).valueOf();
   assert.deepEqual(logs, []);
 });
@@ -346,8 +309,6 @@ QUnit.module('logging');
   Foo.prototype.$ = function() {};
 
   QUnit.test('should log when using unsupported static API', function(assert) {
-    assert.expect(1);
-
     var objects = [{ 'b': 1 }, { 'b': 2 }, { 'b': 3 }],
       expected = [migrateText('max', [objects, 'b'], objects[2], objects[0])];
 
@@ -356,8 +317,6 @@ QUnit.module('logging');
   });
 
   QUnit.test('should log a specific message once', function(assert) {
-    assert.expect(2);
-
     var foo = new Foo('a'),
       expected = [migrateText('functions', [foo], ['a', '$'], ['a'])];
 
@@ -369,8 +328,6 @@ QUnit.module('logging');
   });
 
   QUnit.test('should not log when both lodashes produce uncomparable values', function(assert) {
-    assert.expect(2);
-
     function Bar(a) { this.a = a; }
     var counter = 0;
 
@@ -388,8 +345,6 @@ QUnit.module('logging');
   });
 
   QUnit.test('should not include ANSI escape codes in logs when in the browser', function(assert) {
-    assert.expect(2);
-
     var paths = [
       '../index.js',
       '../lib/util.js'

--- a/test/index.js
+++ b/test/index.js
@@ -100,264 +100,240 @@ QUnit.module('logging method');
 
 QUnit.module('iteration method');
 
-(function() {
-  QUnit.test('should not invoke `iteratee` in new lodash', function(assert) {
-    assert.expect(8);
+QUnit.test('should not invoke `iteratee` in new lodash', function(assert) {
+  assert.expect(8);
 
-    var count,
-        array = [1],
-        object = { 'a': 1 },
-        iteratee = function() { count++; };
+  var count,
+      array = [1],
+      object = { 'a': 1 },
+      iteratee = function() { count++; };
 
-    _.each(['each', 'eachRight', 'forEach', 'forEachRight'], function(methodName) {
-      count = 0;
-      old[methodName](array, iteratee);
-      assert.strictEqual(count, 1, methodName);
-    });
-
-    _.each(['forIn', 'forInRight', 'forOwn', 'forOwnRight'], function(methodName) {
-      count = 0;
-      old[methodName](object, iteratee);
-      assert.strictEqual(count, 1, methodName);
-    });
+  _.each(['each', 'eachRight', 'forEach', 'forEachRight'], function(methodName) {
+    count = 0;
+    old[methodName](array, iteratee);
+    assert.strictEqual(count, 1, methodName);
   });
-}());
+
+  _.each(['forIn', 'forInRight', 'forOwn', 'forOwnRight'], function(methodName) {
+    count = 0;
+    old[methodName](object, iteratee);
+    assert.strictEqual(count, 1, methodName);
+  });
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('missing methods');
 
-(function() {
-  QUnit.test('should not error on legacy `_.callback` use', function(assert) {
-    assert.expect(1);
+QUnit.test('should not error on legacy `_.callback` use', function(assert) {
+  assert.expect(1);
 
-    old.callback('x');
-    assert.deepEqual(logs, []);
-  });
+  old.callback('x');
+  assert.deepEqual(logs, []);
+});
 
-  QUnit.test('should not error on legacy `_.contains` use', function(assert) {
-    assert.expect(1);
+QUnit.test('should not error on legacy `_.contains` use', function(assert) {
+  assert.expect(1);
 
-    old([1, 2, 3]).contains(2);
-    assert.deepEqual(logs, [renameText('contains')]);
-  });
+  old([1, 2, 3]).contains(2);
+  assert.deepEqual(logs, [renameText('contains')]);
+});
 
-  QUnit.test('should not error on legacy `_.indexBy` use', function(assert) {
-    assert.expect(1);
+QUnit.test('should not error on legacy `_.indexBy` use', function(assert) {
+  assert.expect(1);
 
-    var object = { 'a': 'x' };
+  var object = { 'a': 'x' };
 
-    old(object).indexBy(_.identity).value();
-    assert.deepEqual(logs, [renameText('indexBy')]);
-  });
+  old(object).indexBy(_.identity).value();
+  assert.deepEqual(logs, [renameText('indexBy')]);
+});
 
-  QUnit.test('should not error on legacy `_#run` use', function(assert) {
-    assert.expect(1);
+QUnit.test('should not error on legacy `_#run` use', function(assert) {
+  assert.expect(1);
 
-    old(1).run();
-    assert.deepEqual(logs, [renameText('run')]);
-  });
+  old(1).run();
+  assert.deepEqual(logs, [renameText('run')]);
+});
 
-  QUnit.test('should not error on legacy `_.trunc` use', function(assert) {
-    assert.expect(1);
+QUnit.test('should not error on legacy `_.trunc` use', function(assert) {
+  assert.expect(1);
 
-    var string = 'abcdef',
-        expected = [renameText('trunc'), migrateText('trunc', [string, 3], '...', 'abcdef')];
+  var string = 'abcdef',
+    expected = [renameText('trunc'), migrateText('trunc', [string, 3], '...', 'abcdef')];
 
-    old(string).trunc(3);
-    assert.deepEqual(logs, expected);
-  });
-}());
+  old(string).trunc(3);
+  assert.deepEqual(logs, expected);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('mutator methods');
 
-(function() {
-  QUnit.test('should clone arguments before invoking methods', function(assert) {
-    assert.expect(1);
+QUnit.test('should clone arguments before invoking methods', function(assert) {
+  assert.expect(1);
 
-    var array = [1, 2, 3];
+  var array = [1, 2, 3];
 
-    old.remove(array, function(value) {
-      return value == 2;
-    });
-
-    assert.deepEqual(logs, []);
+  old.remove(array, function(value) {
+    return value == 2;
   });
 
-  QUnit.test('should not double up on value mutations', function(assert) {
-    assert.expect(1);
+  assert.deepEqual(logs, []);
+});
 
-    var array = [1, 2, 3],
-        lastIndex = 0;
+QUnit.test('should not double up on value mutations', function(assert) {
+  assert.expect(1);
 
-    old.remove(array, function(value, index) {
-      if (lastIndex > index) {
-        return true;
-      }
-      lastIndex = index;
-    });
+  var array = [1, 2, 3],
+    lastIndex = 0;
 
-    assert.deepEqual(array, [1, 2, 3]);
+  old.remove(array, function(value, index) {
+    if (lastIndex > index) {
+      return true;
+    }
+    lastIndex = index;
   });
-}());
+
+  assert.deepEqual(array, [1, 2, 3]);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.defer');
 
-(function() {
-  QUnit.test('should not log', function(assert) {
-    assert.expect(1);
+QUnit.test('should not log', function(assert) {
+  assert.expect(1);
 
-    old.defer(_.identity);
-    assert.deepEqual(logs, []);
-  });
-}());
+  old.defer(_.identity);
+  assert.deepEqual(logs, []);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.delay');
 
-(function() {
-  QUnit.test('should not log', function(assert) {
-    assert.expect(1);
+QUnit.test('should not log', function(assert) {
+  assert.expect(1);
 
-    old.delay(_.identity, 1);
-    assert.deepEqual(logs, []);
-  });
-}());
+  old.delay(_.identity, 1);
+  assert.deepEqual(logs, []);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.mixin');
 
-(function() {
-  QUnit.test('should not log', function(assert) {
-    assert.expect(1);
+QUnit.test('should not log', function(assert) {
+  assert.expect(1);
 
-    old.mixin();
-    assert.deepEqual(logs, []);
-  });
-}());
+  old.mixin();
+  assert.deepEqual(logs, []);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.now');
 
-(function() {
-  QUnit.test('should not log', function(assert) {
-    assert.expect(1);
+QUnit.test('should not log', function(assert) {
+  assert.expect(1);
 
-    old.now();
-    assert.deepEqual(logs, []);
-  });
-}());
+  old.now();
+  assert.deepEqual(logs, []);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.runInContext');
 
-(function() {
-  QUnit.test('should accept a `context` argument', function(assert) {
-    assert.expect(1);
+QUnit.test('should accept a `context` argument', function(assert) {
+  assert.expect(1);
 
-    var count = 0;
+  var count = 0;
 
-    var now = function() {
-      count++;
-      return Date.now();
-    };
+  var now = function() {
+    count++;
+    return Date.now();
+  };
 
-    var lodash = old.runInContext({
-      'Date': function() {
-        return { 'getTime': now };
-      }
-    });
-
-    lodash.now();
-    assert.strictEqual(count, 1);
+  var lodash = old.runInContext({
+    'Date': function() {
+      return { 'getTime': now };
+    }
   });
 
-  QUnit.test('should not log', function(assert) {
-    assert.expect(1);
+  lodash.now();
+  assert.strictEqual(count, 1);
+});
 
-    old.runInContext();
-    assert.deepEqual(logs, []);
-  });
+QUnit.test('should not log', function(assert) {
+  assert.expect(1);
 
-  QUnit.test('should wrap results', function(assert) {
-    assert.expect(1);
+  old.runInContext();
+  assert.deepEqual(logs, []);
+});
 
-    var lodash = old.runInContext(),
-        objects = [{ 'a': 1 }, { 'a': 2 }, { 'a': 3 }],
-        expected = migrateText('max', [objects, 'a'], objects[2], objects[0]);
+QUnit.test('should wrap results', function(assert) {
+  assert.expect(1);
 
-    lodash.max(objects, 'a');
-    assert.strictEqual(_.last(logs), expected);
-  });
-}());
+  var lodash = old.runInContext(),
+    objects = [{ 'a': 1 }, { 'a': 2 }, { 'a': 3 }],
+    expected = migrateText('max', [objects, 'a'], objects[2], objects[0]);
+
+  lodash.max(objects, 'a');
+  assert.strictEqual(_.last(logs), expected);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.sample');
 
-(function() {
-  QUnit.test('should work when chaining', function(assert) {
-    assert.expect(2);
+QUnit.test('should work when chaining', function(assert) {
+  assert.expect(2);
 
-    var array = [1],
-        wrapped = old(array);
+  var array = [1],
+    wrapped = old(array);
 
-    assert.strictEqual(wrapped.sample(), 1);
-    assert.deepEqual(wrapped.sample(1).value(), [1]);
-  });
-}());
+  assert.strictEqual(wrapped.sample(), 1);
+  assert.deepEqual(wrapped.sample(1).value(), [1]);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.times');
 
-(function() {
-  QUnit.test('should only invoke `iteratee` in new lodash when it contains a `return` statement', function(assert) {
-    assert.expect(2);
+QUnit.test('should only invoke `iteratee` in new lodash when it contains a `return` statement', function(assert) {
+  assert.expect(2);
 
-    var count= 0;
-    old.times(1, function() { count++; });
-    assert.strictEqual(count, 1);
+  var count= 0;
+  old.times(1, function() { count++; });
+  assert.strictEqual(count, 1);
 
-    count = 0;
-    old.times(1, function() { count++; return; });
-    assert.strictEqual(count, 2);
-  });
-}());
+  count = 0;
+  old.times(1, function() { count++; return; });
+  assert.strictEqual(count, 2);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old.uniqueId');
 
-(function() {
-  QUnit.test('should not log', function(assert) {
-    assert.expect(1);
+QUnit.test('should not log', function(assert) {
+  assert.expect(1);
 
-    old.uniqueId();
-    assert.deepEqual(logs, []);
-  });
-}());
+  old.uniqueId();
+  assert.deepEqual(logs, []);
+});
 
 /*----------------------------------------------------------------------------*/
 
 QUnit.module('old#valueOf');
 
-(function() {
-  QUnit.test('should not log', function(assert) {
-    assert.expect(1);
+QUnit.test('should not log', function(assert) {
+  assert.expect(1);
 
-    old([1]).valueOf();
-    assert.deepEqual(logs, []);
-  });
-}());
+  old([1]).valueOf();
+  assert.deepEqual(logs, []);
+});
 
 /*----------------------------------------------------------------------------*/
 
@@ -373,7 +349,7 @@ QUnit.module('logging');
     assert.expect(1);
 
     var objects = [{ 'b': 1 }, { 'b': 2 }, { 'b': 3 }],
-        expected = [migrateText('max', [objects, 'b'], objects[2], objects[0])];
+      expected = [migrateText('max', [objects, 'b'], objects[2], objects[0])];
 
     old.max(objects, 'b');
     assert.deepEqual(logs, expected);
@@ -383,7 +359,7 @@ QUnit.module('logging');
     assert.expect(2);
 
     var foo = new Foo('a'),
-        expected = [migrateText('functions', [foo], ['a', '$'], ['a'])];
+      expected = [migrateText('functions', [foo], ['a', '$'], ['a'])];
 
     old.functions(foo);
     assert.deepEqual(logs, expected);


### PR DESCRIPTION
Better to view this diff with [whitespace toggled off](48/files?w=1).

The first change removes the unnecessary IIFEs around the test modules. They aren't being used and account for 24 lines of unnecessary code. If a function wrapper is necessary around each module of tests, would it not be better to use QUnit's facility for nesting tests under a module (via the 3rd argument to `QUnit.module`)?

The second change is to remove the `assert.expect` lines. The expectations aren't necessary when the assertions are directly in the test function (as opposed to being in callbacks). This change seems more stylistic than it really is. The main purpose for this change is to prepare for custom assertions (`assert.rename`, `assert.migrate`, etc) of which a couple do multiple internal assertions which would cause the expect numbers to appear to be wrong anyway.

All in all, 70 lines that aren't directly adding value.