### PR TITLE
Fix argument mutation test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -179,11 +179,11 @@ QUnit.module('mutator methods');
 
     var array = [1, 2, 3];
 
-    old.remove(array, function(value) {
-      return value == 2;
+    old.remove(array, function(value, index) {
+      return index == 0;
     });
 
-    assert.deepEqual(logs, []);
+    assert.deepEqual(array, [2, 3]);
   });
 
   QUnit.test('should not double up on value mutations', function(assert) {


### PR DESCRIPTION
This test wasn't asserting against the args being mutated. Changing the
code to *not* clone the args should have caused this test to fail, but
it didn't because it was asserting the wrong thing.